### PR TITLE
correct cwd calculation - `cwd` being rewritten to `undefined` by `Object.assign` in `npm` plugin

### DIFF
--- a/lib/plugins/normalize.js
+++ b/lib/plugins/normalize.js
@@ -43,7 +43,7 @@ module.exports = (type, pluginsPath, globalOpts, pluginOpts, logger) => {
     const {outputValidator} = PLUGINS_DEFINITIONS[type] || {};
     try {
       logger.log('Call plugin "%s"', type);
-      const result = await func(cloneDeep(input));
+      const result = await func({ ...cloneDeep(input), cwd: process.cwd() });
       if (outputValidator && !outputValidator(result)) {
         throw getError(`E${type.toUpperCase()}OUTPUT`, {result, pluginName});
       }


### PR DESCRIPTION
This solves for that, otherwise I'm unable to get passed this error. Thoughts?

EDIT: Still running into issues w/ the branch

1. I have 4.x and 1.x tags in my history, but it thinks the "next" pre-release is 1.x. Ugh.
2. Not honoring `dry-run` and cutting releases when it shouldn't.

I believe I'll abandon the effort to get this branch to "work" and just focus on the npm module config 